### PR TITLE
Don't forget self

### DIFF
--- a/dexcom_reader/database_records.py
+++ b/dexcom_reader/database_records.py
@@ -26,7 +26,7 @@ class BaseDatabaseRecord(object):
   @property
   def FMT(self):
     self._CheckFormat()
-    return _ClassFormat()
+    return self._ClassFormat()
 
   @property
   def SIZE(self):


### PR DESCRIPTION
'_ClassFormat' in an undefined name in this context which could raise a [NameError](https://docs.python.org/3/library/exceptions.html?highlight=nameerror#NameError) at runtime.

flake8 testing of https://github.com/openaps/dexcom_reader on Python 2.7.13

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./dexcom_reader/database_records.py:29:12: F821 undefined name '_ClassFormat'
    return _ClassFormat()
           ^
```