### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python
+python:
+  - "2.7"
+  - "3.6"
+matrix:
+  allow_failures:
+    - python: "3.6"
+install:
+  - pip install flake8
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script: true

--- a/dexcom_reader/database_records.py
+++ b/dexcom_reader/database_records.py
@@ -1,8 +1,14 @@
-import crc16
-import constants
+from __future__ import absolute_import
+from . import crc16
+from . import constants
 import struct
-import util
+from . import util
 import binascii
+
+try:
+  xrange          # Python 2
+except NameError:
+  xrange = range  # Python 3
 
 
 class BaseDatabaseRecord(object):
@@ -26,7 +32,7 @@ class BaseDatabaseRecord(object):
   @property
   def FMT(self):
     self._CheckFormat()
-    return _ClassFormat()
+    return self._ClassFormat()
 
   @property
   def SIZE(self):

--- a/dexcom_reader/packetwriter.py
+++ b/dexcom_reader/packetwriter.py
@@ -1,4 +1,5 @@
-import crc16
+from __future__ import absolute_import
+from . import crc16
 import struct
 
 class PacketWriter(object):

--- a/dexcom_reader/readdata.py
+++ b/dexcom_reader/readdata.py
@@ -1,16 +1,23 @@
-import crc16
-import constants
-import database_records
+from __future__ import print_function
+from __future__ import absolute_import
+from . import crc16
+from . import constants
+from . import database_records
 import datetime
 import serial
 import sys
 import time
-import packetwriter
+from . import packetwriter
 import struct
 import re
-import util
+from . import util
 import xml.etree.ElementTree as ET
 import platform
+
+try:
+  xrange          # Python 2
+except NameError:
+  xrange = range  # Python 3
 
 
 class ReadPacket(object):
@@ -44,16 +51,16 @@ class Dexcom(object):
       print ('Found %s S/N: %s'
              % (dex.GetFirmwareHeader().get('ProductName'),
                 dex.ReadManufacturingData().get('SerialNumber')))
-      print 'Transmitter paired: %s' % dex.ReadTransmitterId()
-      print 'Battery Status: %s (%d%%)' % (dex.ReadBatteryState(),
-                                           dex.ReadBatteryLevel())
-      print 'Record count:'
-      print '- Meter records: %d' % (len(dex.ReadRecords('METER_DATA')))
-      print '- CGM records: %d' % (len(dex.ReadRecords('EGV_DATA')))
+      print('Transmitter paired: %s' % dex.ReadTransmitterId())
+      print('Battery Status: %s (%d%%)' % (dex.ReadBatteryState(),
+                                           dex.ReadBatteryLevel()))
+      print('Record count:')
+      print('- Meter records: %d' % (len(dex.ReadRecords('METER_DATA'))))
+      print('- CGM records: %d' % (len(dex.ReadRecords('EGV_DATA'))))
       print ('- CGM commitable records: %d'
              % (len([not x.display_only for x in dex.ReadRecords('EGV_DATA')])))
-      print '- Event records: %d' % (len(dex.ReadRecords('USER_EVENT_DATA')))
-      print '- Insertion records: %d' % (len(dex.ReadRecords('INSERTION_TIME')))
+      print('- Event records: %d' % (len(dex.ReadRecords('USER_EVENT_DATA'))))
+      print('- Insertion records: %d' % (len(dex.ReadRecords('INSERTION_TIME'))))
 
   def __init__(self, port):
     self._port_name = port

--- a/dexcom_reader/record_test.py
+++ b/dexcom_reader/record_test.py
@@ -1,14 +1,16 @@
-import readdata
+from __future__ import print_function
+from __future__ import absolute_import
+from . import readdata
 
 dd = readdata.Dexcom.FindDevice()
 dr = readdata.Dexcom(dd)
 meter_records = dr.ReadRecords('METER_DATA')
-print 'First Meter Record = '
-print meter_records[0]
-print 'Last Meter Record ='  
-print meter_records[-1]
+print('First Meter Record = ')
+print(meter_records[0])
+print('Last Meter Record =')  
+print(meter_records[-1])
 insertion_records = dr.ReadRecords('INSERTION_TIME')
-print 'First Insertion Record = '
-print insertion_records[0]
-print 'Last Insertion Record = '
-print insertion_records[-1]
+print('First Insertion Record = ')
+print(insertion_records[0])
+print('Last Insertion Record = ')
+print(insertion_records[-1])

--- a/dexcom_reader/util.py
+++ b/dexcom_reader/util.py
@@ -1,4 +1,5 @@
-import constants
+from __future__ import absolute_import
+from . import constants
 import datetime
 import os
 import platform

--- a/ez_setup.py
+++ b/ez_setup.py
@@ -298,7 +298,8 @@ def _extractall(self, path=".", members=None):
     # Reverse sort directories.
     if sys.version_info < (2, 4):
         def sorter(dir1, dir2):
-            return cmp(dir1.name, dir2.name)
+            # cmp: not Python 3 compatible but use of ez_setup.py is deprecated
+            return cmp(dir1.name, dir2.name)  # noqa cmp not Python3 compatible
         directories.sort(sorter)
         directories.reverse()
     else:


### PR DESCRIPTION
__Ready for review__: These changes make the code syntax compatible with both Python 2 and Python 3. There would definitely be more work required to complete the port of the code to Python 3 but this is a minimal, safe first step.

See Stage 1: "safe" fixes http://python-future.org/automatic_conversion.html#stage-1-safe-fixes

$ pip install future
$ futurize --stage1 -w **/*.py
$ git commit --all -m "Modernize Python 2 code to get ready for Python 3"
$ git push --set-upstream origin modernize-python2-code

A .travis.yml will look for syntax errors and undefined names in the code which could raise NameError at runtime.  The owner of the `openaps` id would need to go to https://travis-ci.org/profile and turn the repository switch __on__ for the testing to begin on future PRs.