### PR TITLE
Support for Dexcom touchscreen receivers

### DIFF
--- a/dexcom_reader/constants.py
+++ b/dexcom_reader/constants.py
@@ -9,8 +9,8 @@ class CrcError(Error):
   """Failed to CRC properly."""
 
 
-DEXCOM_G4_USB_VENDOR = 0x22a3
-DEXCOM_G4_USB_PRODUCT = 0x0047
+DEXCOM_USB_VENDOR = 0x22a3
+DEXCOM_USB_PRODUCT = 0x0047
 
 BASE_TIME = datetime.datetime(2009, 1, 1)
 
@@ -92,5 +92,3 @@ LANGUAGES = {
   0: None,
   1033: 'ENGLISH',
 }
-
-

--- a/dexcom_reader/database_records.py
+++ b/dexcom_reader/database_records.py
@@ -335,4 +335,5 @@ class G5EGVRecord (EGVRecord):
   def full_trend(self):
     return self.data[12]
 
-
+class G6EGVRecord (G5EGVRecord):
+  FORMAT = '<2IHBBBBBBBBBcBBBH'


### PR DESCRIPTION
This PR:

* Changes the USB VID/PID constant name to better reflect that it applies to all Dexcom receivers (G4, G5, G6)
* Adds Meter Data and EGV Data classes to support the updated data structure in the G5/G6 touchscreen receivers
* Uses the revision field when reading database tables to judge whether original, G5, or G6 structures should be used