### PR TITLE
Update setup.py for G6 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ def readme():
         return f.read()
 
 setup(name='dexcom_reader',
-    version='0.1.10', # http://semver.org/
-    description='Audit, and inspect data from Dexcom G4.',
+    version='0.1.11', # http://semver.org/
+    description='Audit, and inspect data from Dexcom G4, G5, and G6 receivers.',
     long_description=readme(),
     author="Will Nowak",
     # I'm just maintaining the package, @compbrain authored it.


### PR DESCRIPTION
Bump the version number so people upgrading using `oref0-setup` get this when they upgrade `openaps` to 0.2.2-dev

Discussion here: https://github.com/openaps/openaps/pull/139#issuecomment-455010251

I believe this has to be updated in Pypi so that Travis doesn't fail the `openaps` build:

```
Installed /home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/openaps-0.2.2.dev0-py2.7.egg
Processing dependencies for openaps==0.2.2.dev0
Searching for dexcom_reader>=0.1.11
Reading https://pypi.python.org/simple/dexcom_reader/
No local packages or working download links found for dexcom_reader>=0.1.11
error: Could not find suitable distribution for Requirement.parse('dexcom_reader>=0.1.11')
```