### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/dexcom_reader/database_records.py
+++ b/dexcom_reader/database_records.py
@@ -15,7 +15,7 @@ class BaseDatabaseRecord(object):
 
   @classmethod
   def _CheckFormat(cls):
-    if cls.FORMAT is None or not cls.FORMAT:
+    if not cls.FORMAT:
       raise NotImplementedError("Subclasses of %s need to define FORMAT"
                                 % cls.__name__)
 

--- a/dexcom_reader/database_records.py
+++ b/dexcom_reader/database_records.py
@@ -4,6 +4,11 @@ import struct
 import util
 import binascii
 
+try:
+  xrange
+except NameError:
+  xrange = range
+
 
 class BaseDatabaseRecord(object):
   FORMAT = None

--- a/dexcom_reader/database_records.py
+++ b/dexcom_reader/database_records.py
@@ -26,12 +26,12 @@ class BaseDatabaseRecord(object):
 
   @classmethod
   def _ClassSize(cls):
-    return cls._ClassFormat().size  # noqa: F821
+    return cls._ClassFormat().size
 
   @property
   def FMT(self):
     self._CheckFormat()
-    return _ClassFormat()
+    return self._ClassFormat()
 
   @property
   def SIZE(self):

--- a/dexcom_reader/database_records.py
+++ b/dexcom_reader/database_records.py
@@ -26,7 +26,7 @@ class BaseDatabaseRecord(object):
 
   @classmethod
   def _ClassSize(cls):
-    return cls._ClassFormat().size
+    return cls._ClassFormat().size  # noqa: F821
 
   @property
   def FMT(self):

--- a/dexcom_reader/readdata.py
+++ b/dexcom_reader/readdata.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import crc16
 import constants
 import database_records
@@ -11,6 +12,11 @@ import re
 import util
 import xml.etree.ElementTree as ET
 import platform
+
+try:
+  xrange
+except NameError:
+  xrange = range
 
 
 class ReadPacket(object):
@@ -44,16 +50,16 @@ class Dexcom(object):
       print ('Found %s S/N: %s'
              % (dex.GetFirmwareHeader().get('ProductName'),
                 dex.ReadManufacturingData().get('SerialNumber')))
-      print 'Transmitter paired: %s' % dex.ReadTransmitterId()
-      print 'Battery Status: %s (%d%%)' % (dex.ReadBatteryState(),
-                                           dex.ReadBatteryLevel())
-      print 'Record count:'
-      print '- Meter records: %d' % (len(dex.ReadRecords('METER_DATA')))
-      print '- CGM records: %d' % (len(dex.ReadRecords('EGV_DATA')))
+      print('Transmitter paired: %s' % dex.ReadTransmitterId())
+      print('Battery Status: %s (%d%%)' % (dex.ReadBatteryState(),
+                                           dex.ReadBatteryLevel()))
+      print('Record count:')
+      print('- Meter records: %d' % (len(dex.ReadRecords('METER_DATA'))))
+      print('- CGM records: %d' % (len(dex.ReadRecords('EGV_DATA'))))
       print ('- CGM commitable records: %d'
              % (len([not x.display_only for x in dex.ReadRecords('EGV_DATA')])))
-      print '- Event records: %d' % (len(dex.ReadRecords('USER_EVENT_DATA')))
-      print '- Insertion records: %d' % (len(dex.ReadRecords('INSERTION_TIME')))
+      print('- Event records: %d' % (len(dex.ReadRecords('USER_EVENT_DATA'))))
+      print('- Insertion records: %d' % (len(dex.ReadRecords('INSERTION_TIME'))))
 
   def __init__(self, port):
     self._port_name = port

--- a/dexcom_reader/readdata.py
+++ b/dexcom_reader/readdata.py
@@ -47,17 +47,17 @@ class Dexcom(object):
       sys.exit(1)
     else:
       dex = cls(device)
-      print ('Found %s S/N: %s'
-             % (dex.GetFirmwareHeader().get('ProductName'),
-                dex.ReadManufacturingData().get('SerialNumber')))
+      print('Found %s S/N: %s'
+            % (dex.GetFirmwareHeader().get('ProductName'),
+               dex.ReadManufacturingData().get('SerialNumber')))
       print('Transmitter paired: %s' % dex.ReadTransmitterId())
       print('Battery Status: %s (%d%%)' % (dex.ReadBatteryState(),
                                            dex.ReadBatteryLevel()))
       print('Record count:')
       print('- Meter records: %d' % (len(dex.ReadRecords('METER_DATA'))))
       print('- CGM records: %d' % (len(dex.ReadRecords('EGV_DATA'))))
-      print ('- CGM commitable records: %d'
-             % (len([not x.display_only for x in dex.ReadRecords('EGV_DATA')])))
+      print('- CGM commitable records: %d'
+            % (len([not x.display_only for x in dex.ReadRecords('EGV_DATA')])))
       print('- Event records: %d' % (len(dex.ReadRecords('USER_EVENT_DATA'))))
       print('- Insertion records: %d' % (len(dex.ReadRecords('INSERTION_TIME'))))
 

--- a/dexcom_reader/record_test.py
+++ b/dexcom_reader/record_test.py
@@ -1,14 +1,15 @@
+from __future__ import print_function
 import readdata
 
 dd = readdata.Dexcom.FindDevice()
 dr = readdata.Dexcom(dd)
 meter_records = dr.ReadRecords('METER_DATA')
-print 'First Meter Record = '
-print meter_records[0]
-print 'Last Meter Record ='  
-print meter_records[-1]
+print('First Meter Record = ')
+print(meter_records[0])
+print('Last Meter Record =')  
+print(meter_records[-1])
 insertion_records = dr.ReadRecords('INSERTION_TIME')
-print 'First Insertion Record = '
-print insertion_records[0]
-print 'Last Insertion Record = '
-print insertion_records[-1]
+print('First Insertion Record = ')
+print(insertion_records[0])
+print('Last Insertion Record = ')
+print(insertion_records[-1])

--- a/dexcom_reader/util.py
+++ b/dexcom_reader/util.py
@@ -42,12 +42,12 @@ def osx_find_usbserial(vendor, product):
           else:
             break
 
-    if type(v) == list:
+    if isinstance(v, list):
       for x in v:
         out = recur(x)
         if out is not None:
           return out
-    elif type(v) == dict or issubclass(type(v), dict):
+    elif isinstance(v, dict) or issubclass(type(v), dict):
       for x in v.values():
         out = recur(x)
         if out is not None:


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.